### PR TITLE
Fix some mobile scaling issues

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,12 +2,13 @@ body {
 	font-family: Arial, sans-serif;
 	text-align: center;
 	background-image: url('icons/background.jpg');
+	background-attachment: fixed;
 	background-size: cover;
 	background-repeat: no-repeat;
 	background-position: center center;
 	background-color: #ffdaf4;
 	color: #6a0572;
-	padding: 100px;
+	padding: 10px 20px;
 }
 
 .container {
@@ -63,6 +64,21 @@ p {
 
 .join-button:hover {
 	background-color: #6d3a83;
+}
+
+@media (max-width: 768px) {
+	.back-button,
+	.join-button {
+		display: block;
+		font-size: 16px;
+		text-align: center;
+		margin-top: 10px;
+	}
+
+	.nav {
+		display: flex;
+		flex-direction: column;
+	}
 }
 
 .role-icons img {


### PR DESCRIPTION
The content area should now be a bit wider on phones and the buttons get spread across multiple lines instead of all them getting crammed to a singular line.

Also the background image now fills the entire screen no matter the aspect ratio, however the moving background had to be sacrificed in the process